### PR TITLE
fix: typecheck & build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ $ yarn build:mac
 # For Linux
 $ yarn build:linux
 ```
+
 # electron-vite-boilerplate

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "lint": "eslint . --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
-    "typecheck:web": "tsc --noEmit -p; tsconfig.web.json --composite false",
+    "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "yarn run typecheck:node && npm run typecheck:web",
     "start": "electron-vite preview",
     "dev": "electron-vite dev",

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,10 +3,10 @@ import './assets/main.css'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './pages/App'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import LoginPage from './pages/LoginPage'
 
-const router = createBrowserRouter([
+const router = createMemoryRouter([
   { path: '/', element: <App /> },
   { path: '/login', element: <LoginPage /> }
 ])

--- a/src/renderer/src/pages/App.tsx
+++ b/src/renderer/src/pages/App.tsx
@@ -10,8 +10,10 @@ const emitter = new IpcEmitter<IpcEvents>()
 
 function App(): JSX.Element {
   useEffect(() => {
-    ipc.on('ready', (e, arg) => {
-      console.log(arg) // handle the 'ready' event
+    ipc.on('ready', (_, arg) => {
+      // handle the 'ready' event
+      //using underscore, we can indicate the parameter is internally unused :)
+      console.log(arg)
     })
   }, [])
 


### PR DESCRIPTION
### Description
- Corrected a typo in package.json script
- After build, Page not Found error occurred. The reason was BrowserRouter in react-router. 
I changed to MemoryRouter.